### PR TITLE
fix: Values of 'Age' and 'Deutschlandticket' are stored properly in localStorage for user form. (closes #134)

### DIFF
--- a/components/SearchForm/useSearchFormData.ts
+++ b/components/SearchForm/useSearchFormData.ts
@@ -70,19 +70,19 @@ const updateLocalStorage = (updates: Updates) => {
 	if (updates.bahnCard !== undefined) {
 		localStorage.setItem("betterbahn/settings/bahnCard", updates.bahnCard);
 	}
-	if (updates.hasDeutschlandTicket !== null) {
+	if (updates.hasDeutschlandTicket !== undefined) {
 		localStorage.setItem(
 			"betterbahn/settings/hasDeutschlandTicket",
 			String(updates.hasDeutschlandTicket)
 		);
 	}
-	if (updates.passengerAge !== null) {
+	if (updates.passengerAge !== undefined) {
 		localStorage.setItem(
 			"betterbahn/settings/passengerAge",
-			String(updates.passengerAge || '')
+			String(updates.passengerAge || "")
 		);
 	}
-	if(updates.travelClass !== undefined) {
+	if (updates.travelClass !== undefined) {
 		localStorage.setItem(
 			"betterbahn/settings/travelClass",
 			updates.travelClass


### PR DESCRIPTION
## Issue description:
> When I set the 4 settings (Bahncard, age, Deutschlandticket, class) that information is (mostly) stored, and the fields still filled when reloading the page. Age and Deutschlandticket are not both being stored, though. Whenever I set the age, the Deutschlandticket field is empty after reloading the page and vice versa.

## Reproduction of Bug:
[age_deutschlandticket_bug_without_fix.webm](https://github.com/user-attachments/assets/811bf699-2ac0-4d86-8cda-96cc3643d964)

## Behaviour after Bugfix:
[age_deutschlandticket_bug_after_fix.webm](https://github.com/user-attachments/assets/27d5f8f9-00a7-4de8-b62d-71434ac7c116)

## Tested with:
OS: 
- Ubuntu 22.04.5 LTS

Browsers:
- Chrome Version 141.0.7390.54
- Firefox Version 143.0.4
